### PR TITLE
Add macro to ease creating tagged bools

### DIFF
--- a/include/ak_toolkit/tagged_bool.hpp
+++ b/include/ak_toolkit/tagged_bool.hpp
@@ -47,8 +47,8 @@ using tagged_bool_ns::tagged_bool; // with this tagged_bool is in namespace xpli
 // A helper macro to reduce boiler plate when creating tagged bools, e.g.,
 //   AKT_MAKE_TAGGED_BOOL( is_ready );
 //   AKT_MAKE_TAGGED_BOOL( has_signaled );
-#define AKT_MAKE_TAGGED_BOOL( Name ) \
-    class Name##ExplicitBoolTag {};  \
+#define AKT_MAKE_TAGGED_BOOL( Name )                                   \
+    class Name##ExplicitBoolTag { Name##ExplicitBoolTag() = delete; }; \
     using Name = ::ak_toolkit::xplicit::tagged_bool< Name##ExplicitBoolTag >
 
 #endif

--- a/include/ak_toolkit/tagged_bool.hpp
+++ b/include/ak_toolkit/tagged_bool.hpp
@@ -47,8 +47,7 @@ using tagged_bool_ns::tagged_bool; // with this tagged_bool is in namespace xpli
 // A helper macro to reduce boiler plate when creating tagged bools, e.g.,
 //   AKT_MAKE_TAGGED_BOOL( is_ready );
 //   AKT_MAKE_TAGGED_BOOL( has_signaled );
-#define AKT_MAKE_TAGGED_BOOL( Name )                                   \
-    class Name##ExplicitBoolTag { Name##ExplicitBoolTag() = delete; }; \
-    using Name = ::ak_toolkit::xplicit::tagged_bool< Name##ExplicitBoolTag >
+#define AKT_MAKE_TAGGED_BOOL( Name ) \
+    using Name = ::ak_toolkit::xplicit::tagged_bool< class Name##ExplicitBoolTag >
 
 #endif

--- a/include/ak_toolkit/tagged_bool.hpp
+++ b/include/ak_toolkit/tagged_bool.hpp
@@ -44,4 +44,11 @@ using tagged_bool_ns::tagged_bool; // with this tagged_bool is in namespace xpli
 }
 }
 
+// A helper macro to reduce boiler plate when creating tagged bools, e.g.,
+//   AKT_MAKE_TAGGED_BOOL( is_ready );
+//   AKT_MAKE_TAGGED_BOOL( has_signaled );
+#define AKT_MAKE_TAGGED_BOOL( Name ) \
+    class Name##ExplicitBoolTag {};  \
+    using Name = ::ak_toolkit::xplicit::tagged_bool< Name##ExplicitBoolTag >
+
 #endif


### PR DESCRIPTION
This pull request adds a macro to eliminate boilerplate code when defining a tagged bool. At present, one has to do this to create some `tagged_bool`s:
```cpp
class is_ready_tag {};
using is_ready = ak_toolkit::xplicit::tagged_bool< is_ready_tag >;
class has_signaled_tag {};
using is_ready = ak_toolkit::xplicit::tagged_bool< has_signaled_tag >;
```
Or:
```cpp
using is_ready = ak_toolkit::xplicit::tagged_bool< class is_ready_tag >;
using is_ready = ak_toolkit::xplicit::tagged_bool< class has_signaled_tag >;
```
With this change, the macro handles the boilerplate:
```cpp
AKT_MAKE_TAGGED_BOOL( is_ready );
AKT_MAKE_TAGGED_BOOL( has_signaled );
```

