### PR TITLE
allow tagged_bool comparisons with normal bools

### DIFF
--- a/include/ak_toolkit/tagged_bool.hpp
+++ b/include/ak_toolkit/tagged_bool.hpp
@@ -34,7 +34,12 @@ public:
     constexpr tagged_bool operator!() const { return tagged_bool{!value}; }
     
     friend constexpr bool operator==(tagged_bool l, tagged_bool r) { return l.value == r.value; }
+    friend constexpr bool operator==(tagged_bool l, bool r) { return l.value == r; }
+    friend constexpr bool operator==(bool l, tagged_bool r) { return l == r.value; }
+
     friend constexpr bool operator!=(tagged_bool l, tagged_bool r) { return l.value != r.value; }
+    friend constexpr bool operator!=(tagged_bool l, bool r) { return l.value != r; }
+    friend constexpr bool operator!=(bool l, tagged_bool r) { return l != r.value; }
 };
 
 }

--- a/test/test_explicit.cpp
+++ b/test/test_explicit.cpp
@@ -173,6 +173,18 @@ void demonstrate_tagged_bool()
   if (a) assert (true);
   else   assert (false); 
 
+  if (a == true) assert(true);
+  else   assert(false);
+
+  if (true == a) assert(true);
+  else   assert(false);
+
+  if (a != false) assert(true);
+  else   assert(false);
+
+  if (false != a) assert(true);
+  else   assert(false);
+
   constexpr BoolB ba {a};
   assert (ba);
   static_assert (ba && a, "failed tagged_bool");


### PR DESCRIPTION
eg. if( myTaggedBool == false ){}

I saw that you wanted to generally prevent implicit conversions, but this use case happens a lot in our code base so thought it might be an exception you were interested in.