### PR TITLE
tagged_bool: Add support for default value

### DIFF
--- a/doc/tagged_bool.md
+++ b/doc/tagged_bool.md
@@ -55,3 +55,10 @@ You declare and use these bool-types as follows:
 void set_status(EngineStarted started, CrewReady ready); // function declaration
 set_status(EngineStarted{true}, CrewReady{true});        // function call
 ```
+
+Depending on the name you choose for the boolean type it may suggest a convenient default value. E.g. in the above example 
+you may want the booleans to have `true` as their default values. This can be achieved with:
+```c++
+using EngineStarted = xplicit::tagged_bool<class EngineStartedTag, true>;
+set_status(EngineStarted{}, CrewReady{false});
+```

--- a/include/ak_toolkit/tagged_bool.hpp
+++ b/include/ak_toolkit/tagged_bool.hpp
@@ -11,17 +11,17 @@ namespace ak_toolkit {
 namespace xplicit {
 namespace tagged_bool_ns { // artificial namespace to prevent ADL into namespace xplicit
 
-template <typename Tag>
+template <typename Tag, bool default_value = false>
 class tagged_bool
 {
     bool value;
     
-    template <typename /*OtherTag*/>
+    template <typename /*OtherTag*/, bool>
         friend class tagged_bool;
     
 public:
   
-    constexpr explicit tagged_bool (bool v) : value {v} {}
+    constexpr explicit tagged_bool (bool v = default_value) : value {v} {}
     
     constexpr explicit tagged_bool (int) = delete;
     constexpr explicit tagged_bool (double) = delete;

--- a/test/test_explicit.cpp
+++ b/test/test_explicit.cpp
@@ -139,6 +139,8 @@ void test_only_when()
 
 typedef tagged_bool<class BoolA_tag> BoolA;
 typedef tagged_bool<class BoolB_tag> BoolB;
+typedef tagged_bool<class isTrue_tag, true> BoolT;
+typedef tagged_bool<class isFalse_tag, false> BoolF;
 
 void static_test_taged_bool_convertability()
 {
@@ -162,7 +164,7 @@ void demonstrate_tagged_bool()
 {
   constexpr BoolA a {true};
   constexpr BoolB b {false};
-  
+
   static_assert (a && !b, "failed tagged_bool");
   assert (a);
   static_assert (!b, "failed tagged_bool");
@@ -182,7 +184,13 @@ void demonstrate_tagged_bool()
   constexpr BoolA a1 {false};
   constexpr BoolA a2 = !a1;
   assert (a2);
+
+  constexpr BoolT isTrue;
+  constexpr BoolF isFalse;
+  static_assert(isTrue, "failed tagged_bool");
+  static_assert(!isFalse, "failed tagged_bool");
 }
+
 
 void test_tagged_bool()
 {


### PR DESCRIPTION
The `tagged_bool` could maybe benefit from a default value, which is `false` by default (following the convention of a default constructed `bool`) but can be overridden by the developer. While this is less explicit, if the name for the tagged_bool type is carefully chosen, the code gets more compact without much loss in explicitness. E.g.:
```
using EngineStarted = xplicit::tagged_bool<class EngineStartedTag, true>;
set_status(EngineStarted{});
```